### PR TITLE
fix search bar

### DIFF
--- a/src/components/views/mainPageView/SearchBar.jsx
+++ b/src/components/views/mainPageView/SearchBar.jsx
@@ -58,6 +58,7 @@ const SearchBar = () => {
   useEffect(() => {
     if (startDate && endDate && startDate > endDate) {
       openNotification('Incorrect time peroid', 'error')
+      setEndDate('')
       setError(true)
     } else {
       setError(false)


### PR DESCRIPTION
when we set wrong endDate - error is displayed and endDate is reset

![Screenshot 2021-04-12 at 23 49 33](https://user-images.githubusercontent.com/26872584/114467169-cdf4f480-9be9-11eb-8b99-b4ed8ff5b5e6.png)
